### PR TITLE
Fixed a small typo: `mstr`->`master`

### DIFF
--- a/docs/docs/task-handling.md
+++ b/docs/docs/task-handling.md
@@ -49,7 +49,7 @@ The task finished successfully.
 ```
 case TASK_UNKNOWN => Unknown
 ```
-The mster has no knowledge of the task. This is typically because either (a) the master never had knowledge of the task, or (b) the master forgot about the task because it garbaged collected its metadata about the task. The task may or may not still be running. When Marathon receives the Unknown message, it expunges the task and starts a new one.
+The master has no knowledge of the task. This is typically because either (a) the master never had knowledge of the task, or (b) the master forgot about the task because it garbaged collected its metadata about the task. The task may or may not still be running. When Marathon receives the Unknown message, it expunges the task and starts a new one.
 
 ```
 case TASK_KILLED => Killed


### PR DESCRIPTION
Fixed a small typo: `mstr`->`master`